### PR TITLE
changed cacert option to string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.2.1
+
+- Changed `cacert` option in `config.schema.yaml` to be string, not boolean
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -21,6 +21,6 @@
     required: false
   cacert:
     description: "Set to True or path to validate certificates"
-    type: "boolean"
+    type: "string"
     secret: false
     required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: st2
 name: st2
 description: StackStorm pack management
-version: 0.2.0
+version: 0.2.1
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
`cacert` can be boolean or string. Our example yaml had `""`, so tests were failing. We hadn't previously run these tests to check `st2.yaml.example` against `config.schema.yaml`