### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.1
 
 - Changed `cacert` option in `config.schema.yaml` to be string, not boolean

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ to `/opt/stackstorm/configs/st2.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 ### Datastore

--- a/actions/actions_list.yaml
+++ b/actions/actions_list.yaml
@@ -2,7 +2,7 @@
 name: "actions.list"
 enabled: true
 description: "Retrieve a list of available StackStorm actions."
-runner_type: "run-python"
+runner_type: "python-script"
 entry_point: "actions_list.py"
 parameters:
   pack:

--- a/actions/check_permissions_anon_data.yaml
+++ b/actions/check_permissions_anon_data.yaml
@@ -3,7 +3,7 @@ name: "check_permissions_anon_data"
 pack: "st2"
 enabled: true
 description: "Check if sending anonymous data is allowed."
-runner_type: run-python
+runner_type: python-script
 entry_point: check_permissions_anon_data.py
 parameters:
     collect_anonymous_data:

--- a/actions/executions_get.yaml
+++ b/actions/executions_get.yaml
@@ -2,7 +2,7 @@
 name: "executions.get"
 enabled: true
 description: "Retrieve details of a single execution."
-runner_type: run-python
+runner_type: python-script
 entry_point: executions_get.py
 parameters:
   id:

--- a/actions/executions_list.yaml
+++ b/actions/executions_list.yaml
@@ -2,7 +2,7 @@
 name: "executions.list"
 enabled: true
 description: "Retrieve a list of executions."
-runner_type: run-python
+runner_type: python-script
 entry_point: executions_list.py
 parameters:
   action:

--- a/actions/executions_re_run.yaml
+++ b/actions/executions_re_run.yaml
@@ -2,7 +2,7 @@
 name: "executions.re_run"
 enabled: true
 description: "Re-run an action execution."
-runner_type: run-python
+runner_type: python-script
 entry_point: executions_re_run.py
 parameters:
   id:

--- a/actions/kv_delete.yaml
+++ b/actions/kv_delete.yaml
@@ -2,7 +2,7 @@
 name: kv.delete
 enabled: true
 description: 'Delete value from datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_delete.py
 parameters:
   key:

--- a/actions/kv_get.yaml
+++ b/actions/kv_get.yaml
@@ -2,7 +2,7 @@
 name: kv.get
 enabled: true
 description: 'Get value from datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_get.py
 parameters:
   key:

--- a/actions/kv_get_object.yaml
+++ b/actions/kv_get_object.yaml
@@ -2,7 +2,7 @@
 name: 'kv.get_object'
 enabled: true
 description: 'Deserialize and retrieve JSON serialized object from a datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_get_object.py
 parameters:
   key:

--- a/actions/kv_grep.yaml
+++ b/actions/kv_grep.yaml
@@ -2,7 +2,7 @@
 name: kv.grep
 enabled: true
 description: 'Grep for values in datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_grep.py
 parameters:
   query:

--- a/actions/kv_set.yaml
+++ b/actions/kv_set.yaml
@@ -2,7 +2,7 @@
 name: kv.set
 enabled: true
 description: 'Set value in datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_set.py
 parameters:
   key:

--- a/actions/kv_set_object.yaml
+++ b/actions/kv_set_object.yaml
@@ -2,7 +2,7 @@
 name: 'kv.set_object'
 enabled: true
 description: 'Serialize and store object in a datastore'
-runner_type: run-python
+runner_type: python-script
 entry_point: kv_set_object.py
 parameters:
   key:

--- a/actions/rules_list.yaml
+++ b/actions/rules_list.yaml
@@ -2,7 +2,7 @@
 name: "rules.list"
 enabled: true
 description: "Retrieve a list of available StackStorm rules"
-runner_type: run-python
+runner_type: python-script
 entry_point: rules_list.py
 parameters:
   pack:

--- a/actions/sensors_list.yaml
+++ b/actions/sensors_list.yaml
@@ -2,7 +2,7 @@
 name: "sensors.list"
 enabled: true
 description: "Retrieve a list of available StackStorm sensors."
-runner_type: run-python
+runner_type: python-script
 entry_point: sensors_list.py
 parameters:
   pack:

--- a/actions/upload_to_s3.yaml
+++ b/actions/upload_to_s3.yaml
@@ -2,7 +2,7 @@
 name: "upload_to_s3"
 enabled: true
 description: "Sends collected data to write-only StackStorm S3 bucket"
-runner_type: "run-python"
+runner_type: "python-script"
 entry_point: "upload_to_s3.py"
 parameters:
   file_name:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: st2
 name: st2
 description: StackStorm pack management
-version: 0.2.1
+version: 0.3.0
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.