### PR TITLE
Fix all actions which use client.query() method

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -100,5 +100,10 @@ class St2BaseAction(Action):
                                                                            method_kwargs))
 
         result = method(**method_kwargs)
+
+        if method_name == 'query' and isinstance(result, tuple) and len(result) == 2:
+            # In StackStorm v2.3.0 method return value has been changed and query now return a
+            # tuple of (result, total_number_of_items)
+            result = result[0]
         result = format_func(result, **format_kwargs or {})
         return result

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -102,8 +102,9 @@ class St2BaseAction(Action):
         result = method(**method_kwargs)
 
         if method_name == 'query' and isinstance(result, tuple) and len(result) == 2:
-            # In StackStorm v2.3.0 method return value has been changed and query now return a
-            # tuple of (result, total_number_of_items)
+            # In StackStorm v2.3.1 method return value has been changed and query() method now
+            # returns a tuple of (result, total_number_of_items)
             result = result[0]
+
         result = format_func(result, **format_kwargs or {})
         return result

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: st2
 name: st2
 description: StackStorm pack management
-version: 0.3.0
+version: 0.3.1
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
Fixes actions which use st2client `query()` method so they work again after a breaking change in https://github.com/StackStorm/st2/issues/3514 which has been included in v2.3.1.

In the future we need to be more careful when we do a breaking client changes like that one. We some how missed that breaking change and I believe we also didn't document it so we need to go back and explicitly document this in upgrade notes of st2 v2.3.

Resolves https://github.com/StackStorm/st2/issues/3606