### PR TITLE
Add "inquiry respond" action and alias

### DIFF
--- a/actions/inquiry_respond.py
+++ b/actions/inquiry_respond.py
@@ -1,0 +1,12 @@
+from lib.action import St2BaseAction
+
+__all__ = [
+    'St2InquiryRespondAction'
+]
+
+
+class St2InquiryRespondAction(St2BaseAction):
+
+    def run(self, id, response):
+        self.client.inquiries.respond(inquiry_id=id,
+                                      inquiry_response=response)

--- a/actions/inquiry_respond.yaml
+++ b/actions/inquiry_respond.yaml
@@ -1,0 +1,15 @@
+---
+name: "inquiry.respond"
+enabled: true
+description: "Respond to an inquiry"
+runner_type: python-script
+entry_point: inquiry_respond.py
+parameters:
+  id:
+    type: "string"
+    description: "ID of inquiry to which to respond"
+    required: true
+  response:
+    type: "object"
+    description: "Response payload"
+    required: false

--- a/aliases/inquiry_respond.yaml
+++ b/aliases/inquiry_respond.yaml
@@ -1,0 +1,17 @@
+---
+name: "st2_inquiry_respond"
+action_ref: "st2.inquiry.respond"
+description: "Respond to an Inquiry"
+formats:
+    - "st2 respond to inquiry {{ id }} with {{ response }}"
+ack:
+  format: |
+        Roger that - let me just make sure this response fits the Inquiry schema.
+  append_url: false
+result:
+    format: |
+        {% if execution.status == "succeeded" -%}
+            Your response to inquiry {{ execution.parameters.id }} was accepted!
+        {%+ else %}
+            Your response to inquiry {{ execution.parameters.id }} did not fit the response schema.
+        {%+ endif %}


### PR DESCRIPTION
This PR introduces a new action, `st2.inquiry.respond`, and an accompanying action-alias for use in chatops. With these, a user can respond to inquiries via chatops (though they will still have to put together the JSON payload themselves).

# Usage

The action can certainly be used on its own or in a workflow, using the Inquiry ID and the response payload:

```bash
vagrant@st2vagrant:~$ st2 run examples.mistral-ask-basic
.
id: 5a1f4411c4da5f4486b09361
action.ref: examples.mistral-ask-basic
parameters: None
status: pausing
start_timestamp: Wed, 29 Nov 2017 23:34:41 UTC
end_timestamp:
+--------------------------+---------+-------+----------+-------------------------------+
| id                       | status  | task  | action   | start_timestamp               |
+--------------------------+---------+-------+----------+-------------------------------+
| 5a1f4411c4da5f4486b09364 | pending | task1 | core.ask | Wed, 29 Nov 2017 23:34:41 UTC |
+--------------------------+---------+-------+----------+-------------------------------+
vagrant@st2vagrant:~$ st2 inquiry list
+--------------------------+-------+-------+------------+------+
| id                       | roles | users | route      | ttl  |
+--------------------------+-------+-------+------------+------+
| 5a1f4411c4da5f4486b09364 |       |       | developers | 1440 |
+--------------------------+-------+-------+------------+------+
vagrant@st2vagrant:~$ st2 inquiry get 5a1f4411c4da5f4486b09364
+----------+--------------------------------------------------------------+
| Property | Value                                                        |
+----------+--------------------------------------------------------------+
| id       | 5a1f4411c4da5f4486b09364                                     |
| roles    |                                                              |
| users    |                                                              |
| route    | developers                                                   |
| ttl      | 1440                                                         |
| schema   | {                                                            |
|          |     "type": "object",                                        |
|          |     "properties": {                                          |
|          |         "secondfactor": {                                    |
|          |             "required": true,                                |
|          |             "type": "string",                                |
|          |             "description": "Please enter second factor for   |
|          | authenticating to "foo" service"                             |
|          |         }                                                    |
|          |     }                                                        |
|          | }                                                            |
+----------+--------------------------------------------------------------+
vagrant@st2vagrant:~$ st2 run st2.inquiry.respond id=5a1f4411c4da5f4486b09364 response='{"secondfactor": "foo"}'
.
id: 5a1f444ec4da5f4486b09366
status: succeeded
parameters:
  id: 5a1f4411c4da5f4486b09364
  response:
    secondfactor: '********'
result:
  exit_code: 0
  result: null
  stderr: ''
  stdout: ''
vagrant@st2vagrant:~$ st2 inquiry list
+----+-------+-------+-------+-----+
| id | roles | users | route | ttl |
+----+-------+-------+-------+-----+
+----+-------+-------+-------+-----+
```

In addition, the provided action-alias makes it possible to call this action from Slack (or another chatops-capable application). The result template also provides a bit of feedback to the user on whether or not their response was accepted:

![screenshot 2017-11-29 15 53 47](https://user-images.githubusercontent.com/4230395/33405506-86bca7fc-d51d-11e7-9dbf-8fdb24a0648f.png)

> Currently, the UX isn't the greatest, since the user will have to manually construct the JSON payload within their chat program, but it's better than nothing for now.

# Dependencies

Some `st2` work needed to take place to prepare for this action, so this should not be merged before the below PRs are merged:

- [x] https://github.com/StackStorm/st2/pull/3865 (Add hooks into st2client)
- [x] https://github.com/StackStorm/st2/pull/3868 (Mask response in parameters for `st2.inquiry.respond` action)

# Documentation

I opened https://github.com/StackStorm/st2docs/pull/672 to explain the new action and action-alias in the Inquiries section, as well as to explain the masking behavior introduced in https://github.com/StackStorm/st2/pull/3868