### PR TITLE
Fix st2.kv.get bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,25 @@
 # Change Log
 
-# 1.0.3
+## 1.0.4
+
+- Added default to decrypt param for `st2.kv.get` to fix bug
+
+## 1.0.3
 
 - Added the option to decrypt a secret for `st2.kv.get`
 
-# 1.0.2
+## 1.0.2
 
 - Fixed description for `st2.kv.grep` action
 
-# 0.3.0
+## 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
 
-# 0.2.1
+## 0.2.1
 
 - Changed `cacert` option in `config.schema.yaml` to be string, not boolean
 
-# 0.2.0
+## 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/actions/kv_get.yaml
+++ b/actions/kv_get.yaml
@@ -16,3 +16,4 @@ parameters:
     type: boolean
     description: 'True if the value is stored as a secret and it should be decrypted before returning it'
     required: False
+    default: False

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 1.0.3
+version: 1.0.4
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
There was no default for the new `decrypt:` parameter. 

When this action was run, if `decrypt` was not specified, it was passed through as `decrypt=None`

In the code this caused problems, because it had a default of `decrypt=False`, but this was overridden by `default=None`. This then caused execution failures.

This change sets the default in the action metadata. 