### PR TITLE
Added new action st2.kv.grep_object and added prefix option to st2.kv.grep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.5
+
+- Added a new option `prefix` to the `st2.kv.grep` action allowing more efficient querying 
+  of the key/value store if the user is looking for all keys that start with a given query.
+
 ## 1.0.4
 
 - Added default to decrypt param for `st2.kv.get` to fix bug

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Added a new option `prefix` to the `st2.kv.grep` action allowing more efficient querying 
   of the key/value store if the user is looking for all keys that start with a given query.
+  
+- Added a new action `st2.kv.grep_object` that greps keys from the k/v store and parses
+  serialized JSON data in each value into objects.
 
 ## 1.0.4
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You can also use dynamic values from the datastore. See the
   datastore.
 * ``kv.set_object`` - Serialize and store object in a datastore. Note: object
   is serialized as JSON.
+* ``kv.grep_object`` - Find datastore items which name matches the provided query
+  amd deserialize their values from JSON serialized objects.
 
 Note: ``kv.set`` and ``kv.get`` actions support compressing value before
 storing it in a datastore and decompressing it when retrieving it from

--- a/actions/kv_grep.py
+++ b/actions/kv_grep.py
@@ -6,7 +6,7 @@ __all__ = [
 
 
 class St2KVPGrepAction(St2BaseAction):
-    def run(self, query, prefix):
+    def run(self, query, prefix=False):
         if prefix:
             _keys = self.client.keys.get_all(prefix=query)
             results = {key.name: key.value for key in _keys}

--- a/actions/kv_grep.py
+++ b/actions/kv_grep.py
@@ -6,11 +6,14 @@ __all__ = [
 
 
 class St2KVPGrepAction(St2BaseAction):
-    def run(self, query):
-        _keys = self.client.keys.get_all()
-        results = {}
-        for key in _keys:
-            if query in key.name:
-                results[key.name] = key.value
-
+    def run(self, query, prefix):
+        if prefix:
+            _keys = self.client.keys.get_all(prefix=query)
+            results = {key.name: key.value for key in _keys}
+        else:
+            _keys = self.client.keys.get_all()
+            results = {}
+            for key in _keys:
+                if query in key.name:
+                    results[key.name] = key.value
         return results

--- a/actions/kv_grep.yaml
+++ b/actions/kv_grep.yaml
@@ -8,3 +8,6 @@ parameters:
   query:
     required: True
     type: string
+  prefix:
+    type: boolean
+    description: "If specified will treat query as a prefix to the key. Using this option makes a more efficient API call if you're looking for all keys that start with a given query string."

--- a/actions/kv_grep.yaml
+++ b/actions/kv_grep.yaml
@@ -11,3 +11,4 @@ parameters:
   prefix:
     type: boolean
     description: "If specified will treat query as a prefix to the key. Using this option makes a more efficient API call if you're looking for all keys that start with a given query string."
+    default: False

--- a/actions/kv_grep_object.py
+++ b/actions/kv_grep_object.py
@@ -8,7 +8,7 @@ __all__ = [
 
 
 class St2KVPGrepObjectAction(St2BaseAction):
-    def run(self, query, prefix):
+    def run(self, query, prefix=False):
         if prefix:
             _keys = self.client.keys.get_all(prefix=query)
             results = {}

--- a/actions/kv_grep_object.py
+++ b/actions/kv_grep_object.py
@@ -1,0 +1,23 @@
+import json
+
+from lib.action import St2BaseAction
+
+__all__ = [
+    'St2KVPGrepObjectAction'
+]
+
+
+class St2KVPGrepObjectAction(St2BaseAction):
+    def run(self, query, prefix):
+        if prefix:
+            _keys = self.client.keys.get_all(prefix=query)
+            results = {}
+            for key in _keys:
+                results[key.name] = json.loads(key.value)
+        else:
+            _keys = self.client.keys.get_all()
+            results = {}
+            for key in _keys:
+                if query in key.name:
+                    results[key.name] = json.loads(key.value)
+        return results

--- a/actions/kv_grep_object.yaml
+++ b/actions/kv_grep_object.yaml
@@ -1,0 +1,13 @@
+---
+name: kv.grep_object
+enabled: true
+description: 'Grep for keys in datastore and deserialize JSON serialized values. This will perform JSON serialization on all values that match the query.'
+runner_type: python-script
+entry_point: kv_grep_object.py
+parameters:
+  query:
+    required: True
+    type: string
+  prefix:
+    type: boolean
+    description: "If specified will treat query as a prefix to the key. Using this option makes a more efficient API call if you're looking for all keys that start with a given query string."

--- a/actions/kv_grep_object.yaml
+++ b/actions/kv_grep_object.yaml
@@ -11,3 +11,4 @@ parameters:
   prefix:
     type: boolean
     description: "If specified will treat query as a prefix to the key. Using this option makes a more efficient API call if you're looking for all keys that start with a given query string."
+    default: False

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 1.0.4
+version: 1.0.5
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
- Added a new option `prefix` to the `st2.kv.grep` action allowing more efficient querying 
  of the key/value store if the user is looking for all keys that start with a given query.
  
- Added a new action `st2.kv.grep_object` that greps keys from the k/v store and parses
  serialized JSON data in each value into objects.