### PR TITLE
Update change log and bump pack version to 1.0.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.6
+
+- Add `executions.get_root` action
+
 ## 1.0.5
 
 - Added a new option `prefix` to the `st2.kv.grep` action allowing more efficient querying 

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 1.0.5
+version: 1.0.6
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Add missing change log entry and bump pack version to `1.0.6`.