### PR TITLE
Executions Create

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.6
+
+- Added executions.create action that allows a workflow to run another action asynchronously.
+  This enables running sub-workflows concurrently and tracking their execution ids.
+
 ## 1.0.5
 
 - Added a new option `prefix` to the `st2.kv.grep` action allowing more efficient querying 

--- a/actions/executions_create.py
+++ b/actions/executions_create.py
@@ -1,0 +1,45 @@
+from lib.action import St2BaseAction
+from st2client.models.action import Execution
+from st2client.commands.resource import ResourceNotFoundError
+
+__all__ = [
+    'St2ExecutionsCreateAction'
+]
+
+
+def format_result(item):
+    if not item:
+        return None
+
+    return item.to_dict()
+
+
+class St2ExecutionsCreateAction(St2BaseAction):
+    def run(self, action, parameters=None):
+        parameters = parameters or {}
+
+        action_resource = self.client.managers['Action'].get_by_ref_or_id(action)
+        if not action_resource:
+            raise ResourceNotFoundError('Action "%s" cannot be found.'
+                                        % action)
+        action_ref = '.'.join([action_resource.pack, action_resource.name])
+
+        execution = Execution()
+        execution.action = action_ref
+        execution.parameters = parameters
+
+        if parameters.get('user'):
+            execution.user = parameters['user']
+
+        if parameters.get('delay'):
+            execution.delay = parameters['delay']
+
+        if not parameters.get('trace_id') and parameters.get('trace_tag'):
+            execution.context = {'trace_context': {'trace_tag': parameters['trace_tag']}}
+
+        if parameters.get('trace_id'):
+            execution.context = {'trace_context': {'id_': parameters['trace_id']}}
+
+        result = self.client.executions.create(instance=execution)
+        result = format_result(item=result)
+        return result

--- a/actions/executions_create.py
+++ b/actions/executions_create.py
@@ -15,7 +15,7 @@ def format_result(item):
 
 
 class St2ExecutionsCreateAction(St2BaseAction):
-    def run(self, action, parameters=None):
+    def run(self, action, parameters=None, user=None, delay=None, trace_id=None, trace_tag=None):
         parameters = parameters or {}
 
         action_resource = self.client.managers['Action'].get_by_ref_or_id(action)
@@ -28,17 +28,17 @@ class St2ExecutionsCreateAction(St2BaseAction):
         execution.action = action_ref
         execution.parameters = parameters
 
-        if parameters.get('user'):
-            execution.user = parameters['user']
+        if user:
+            execution.user = user
 
-        if parameters.get('delay'):
-            execution.delay = parameters['delay']
+        if delay:
+            execution.delay = delay
 
-        if not parameters.get('trace_id') and parameters.get('trace_tag'):
-            execution.context = {'trace_context': {'trace_tag': parameters['trace_tag']}}
+        if not trace_id and trace_tag:
+            execution.context = {'trace_context': {'trace_tag': trace_tag}}
 
-        if parameters.get('trace_id'):
-            execution.context = {'trace_context': {'id_': parameters['trace_id']}}
+        if trace_id:
+            execution.context = {'trace_context': {'id_': trace_id}}
 
         result = self.client.executions.create(instance=execution)
         result = format_result(item=result)

--- a/actions/executions_create.yaml
+++ b/actions/executions_create.yaml
@@ -1,0 +1,15 @@
+---
+name: "executions.create"
+enabled: true
+description: "Create an action execution."
+runner_type: python-script
+entry_point: executions_create.py
+parameters:
+  action:
+    type: "string"
+    description: "ref or id of the action to run"
+    required: true
+  parameters:
+    type: "object"
+    description: "Parameters"
+    required: false

--- a/actions/executions_create.yaml
+++ b/actions/executions_create.yaml
@@ -13,3 +13,19 @@ parameters:
     type: "object"
     description: "Parameters"
     required: false
+  user:
+    type: "string"
+    description: "User under which to run the action (admins only)."
+    required: false
+  delay:
+    type: "string"
+    description: "How long (in milliseconds) to delay the execution before scheduling."
+    required: false
+  trace_id:
+    type: "string"
+    description: "Existing trace id for this execution."
+    required: false
+  trace_tag:
+    type: "string"
+    description: "A trace tag string to track execution later."
+    required: false

--- a/actions/upload_to_s3.py
+++ b/actions/upload_to_s3.py
@@ -1,5 +1,4 @@
 import os
-import httplib
 
 import requests
 
@@ -32,7 +31,7 @@ class UploadToS3(St2BaseAction):
         files = {'file': open(file_name, 'rb')}
         response = requests.put(url=url, files=files)
 
-        if response.status_code in [httplib.OK, httplib.CREATED]:
+        if response.status_code in requests.codes.ok:  # pylint: disable=no-member
             status = 'ok'
             error = None
         else:

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 1.0.5
+version: 1.0.6
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
Transferred from #16 to fix merge conflicts related to versions.

- Added executions_create to support triggering actions (sub-workflows) asynchronously