### PR TITLE
1.3.0 Rules manipulation actions and aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.3.0
+
+- Added `st2.rules.enable`, `st2.rules.disable` actions and chatops commands.
+- Added reading `ST2_ACTION_AUTH_API_KEY` environment variable if API Key is not provided in the pack's config.
+
 ## 1.2.0
 
 - Added `st2.executions.pause`, `st2.executions.resume`, `st2.executions.cancel` actions.
@@ -7,7 +12,7 @@
 ## 1.1.0
 
 - Added decrypt and decompress parameters to `st2.kv.get_object`
-- Fixed cacert=True case in pack's configuration
+- Fixed `cacert=True` case in pack's configuration
 
 ## 1.0.7
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ sensors and more.
   action execution.
 * ``!st2 executions re-run <execution id>`` - Re-run a particular action
   execution.
-* ``!st2 executions cancel <execution id>`` - Pause a particular action
+* ``!st2 executions cancel <execution id>`` - Cancel a particular action
   execution.
 * ``!st2 executions pause <execution id>`` - Pause a particular action
   execution.
 * ``!st2 executions resume <execution id>`` - Resume a particular action
   execution.
+* ``!st2 disable rule <name> from pack <pack>`` - Disable a particular rule.
+* ``!st2 enable rule <name> from pack <pack>`` - Enable a particular rule.

--- a/actions/lib/formatters.py
+++ b/actions/lib/formatters.py
@@ -18,3 +18,7 @@ def format_client_list_result(result, exclude_attributes=None):
 
 def format_result(item):
     return item.to_dict() if item else None
+
+
+def format_rule_update_result(result, exclude_attributes):
+    return format_client_list_result(result=[result], exclude_attributes=exclude_attributes)[0]

--- a/actions/rules_disable.py
+++ b/actions/rules_disable.py
@@ -1,0 +1,18 @@
+from lib.action import St2BaseAction
+from lib.formatters import format_rule_update_result
+
+__all__ = [
+    'St2RulesDisableAction'
+]
+
+
+class St2RulesDisableAction(St2BaseAction):
+    def run(self, pack=None, name=None, exclude=None):
+
+        rule = self._manipulate_rule(pack=pack, name=name, enabled=False)
+        if rule is None or isinstance(rule, str):
+            # error happened
+            return False, rule
+        else:
+            # all good here
+            return True, format_rule_update_result(rule, exclude)

--- a/actions/rules_disable.yaml
+++ b/actions/rules_disable.yaml
@@ -1,0 +1,19 @@
+---
+name: "rules.disable"
+enabled: true
+description: "Disable an existing rule"
+runner_type: python-script
+entry_point: rules_disable.py
+parameters:
+  pack:
+    type: "string"
+    description: "Pack where the rule is in"
+    required: true
+  name:
+    type: "string"
+    description: "Rule name"
+    required: true
+  exclude:
+    type: "array"
+    description: "List of attributes to exclude from results"
+    default: []

--- a/actions/rules_enable.py
+++ b/actions/rules_enable.py
@@ -1,0 +1,18 @@
+from lib.action import St2BaseAction
+from lib.formatters import format_rule_update_result
+
+__all__ = [
+    'St2RulesEnableAction'
+]
+
+
+class St2RulesEnableAction(St2BaseAction):
+    def run(self, pack=None, name=None, exclude=None):
+
+        rule = self._manipulate_rule(pack=pack, name=name, enabled=True)
+        if rule is None or isinstance(rule, str):
+            # error happened
+            return False, rule
+        else:
+            # all good here
+            return True, format_rule_update_result(rule, exclude)

--- a/actions/rules_enable.yaml
+++ b/actions/rules_enable.yaml
@@ -1,0 +1,19 @@
+---
+name: "rules.enable"
+enabled: true
+description: "Enable an existing rule"
+runner_type: python-script
+entry_point: rules_enable.py
+parameters:
+  pack:
+    type: "string"
+    description: "Pack where the rule is in"
+    required: true
+  name:
+    type: "string"
+    description: "Rule name"
+    required: true
+  exclude:
+    type: "array"
+    description: "List of attributes to exclude from results"
+    default: []

--- a/aliases/rules_disable.yaml
+++ b/aliases/rules_disable.yaml
@@ -1,0 +1,19 @@
+---
+name: "st2_rules_disable"
+action_ref: "st2.rules.disable"
+description: "Disable an existing rule."
+formats:
+  - "st2 disable rule {{ name }} from pack {{ pack }}"
+ack:
+  format: "Give me just a moment to disable the rule for you..."
+result:
+  extra:
+    slack:
+      color: "{% if execution.status == 'succeeded' %}#219939{% else %}#d80015{% endif %}"
+  format: |
+    {% set res = execution.result.result %}
+    {% if res is string %}
+    {{ res }}
+    {% else %}
+    Disabled: {{ res.ref }} ({{ res.trigger.ref }} -> {{ res.action.ref }}){{ res.description and ' - ' + res.description }}
+    {% endif %}

--- a/aliases/rules_enable.yaml
+++ b/aliases/rules_enable.yaml
@@ -1,0 +1,19 @@
+---
+name: "st2_rules_enable"
+action_ref: "st2.rules.enable"
+description: "Enable an existing rule."
+formats:
+  - "st2 enable rule {{ name }} from pack {{ pack }}"
+ack:
+  format: "Give me just a moment to enable the rule for you..."
+result:
+  extra:
+    slack:
+      color: "{% if execution.status == 'succeeded' %}#219939{% else %}#d80015{% endif %}"
+  format: |
+    {% set res = execution.result.result %}
+    {% if res is string %}
+    {{ res }}
+    {% else %}
+    Enabled: {{ res.ref }} ({{ res.trigger.ref }} -> {{ res.action.ref }}){{ res.description and ' - ' + res.description }}
+    {% endif %}

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 1.2.0
+version: 1.3.0
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
## 1.3.0

- Added `st2.rules.enable`, `st2.rules.disable` actions and chatops commands.
- Added reading `ST2_ACTION_AUTH_API_KEY` environment variable if API Key is not provided in the pack's config.