### PR TITLE
Re-add Python 2 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.0.1
+
+* Temporarily re-add Python 2 support until StackStorm v3.3 is EOL.
 
 ## 2.0.0
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,7 @@ name: st2
 description: StackStorm utility actions and aliases
 version: 2.0.0
 python_versions:
+  - "2"
   - "3"
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,8 +2,11 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 2.0.0
+version: 2.0.1
 python_versions:
+  # StackStorm v3.3 on Xenial still uses python 2.7
+  # and does not backtrack to find older supported versions,
+  # so leave this here (without tests) until v3.3 is EOL.
   - "2"
   - "3"
 author: StackStorm, Inc.


### PR DESCRIPTION
This pack needs to continue to support Python 2 even if it's not tested with Python 2, because this pack is installed automatically by the one-line installer, and we need to continue to support that for existing v3.3 installations on Ubuntu Xenial 16.04.

I thought StackStorm was smart enough to find the last version of a pack that supported Python 2 (when ST2 is running on Python 2, which v3.3 still does on Ubuntu Xenial), but it's not. It simply grabs the latest pack version it can find, and checks that for Python 2 support. If the pack, in the latest version, doesn't support Python 2, then StackStorm throws up its hands and fails.

It's not ideal to officially support a Python version that we don't test against, but it's better to do that than break installations of our current stable release!

A log excerpt of `vagrant up` with st2vagrant is appended:

```
    st2vagrant: 20210209T111029+0000
    st2vagrant: 20210209T111029+0000 id: 60226da19398ee208e84d4cd
    st2vagrant: 20210209T111029+0000 action.ref: packs.install
    st2vagrant: 20210209T111029+0000 parameters:
    st2vagrant: 20210209T111029+0000   packs:
    st2vagrant: 20210209T111029+0000   - st2
    st2vagrant: 20210209T111029+0000   python3: false
    st2vagrant: 20210209T111029+0000 status: failed
    st2vagrant: 20210209T111029+0000 start_timestamp: Tue, 09 Feb 2021 11:10:25 UTC
    st2vagrant: 20210209T111029+0000 end_timestamp: Tue, 09 Feb 2021 11:10:29 UTC
    st2vagrant: 20210209T111029+0000 result:
    st2vagrant: 20210209T111029+0000   errors:
    st2vagrant: 20210209T111029+0000   - message: Execution failed. See result for details.
    st2vagrant: 20210209T111029+0000     result:
    st2vagrant: 20210209T111029+0000       exit_code: 1
    st2vagrant: 20210209T111029+0000       result: None
    st2vagrant: 20210209T111029+0000       stderr: "Traceback (most recent call last):
    st2vagrant: 20210209T111029+0000   File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/python_runner/python_action_wrapper.py", line 334, in <module>
    st2vagrant: 20210209T111029+0000     obj.run()
    st2vagrant: 20210209T111029+0000   File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/python_runner/python_action_wrapper.py", line 193, in run
    st2vagrant: 20210209T111029+0000     output = action.run(**self._parameters)
    st2vagrant: 20210209T111029+0000   File "/opt/stackstorm/packs/packs/actions/pack_mgmt/download.py", line 86, in run
    st2vagrant: 20210209T111029+0000     logger=self.logger)
    st2vagrant: 20210209T111029+0000   File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/pack_management.py", line 165, in download_pack
    st2vagrant: 20210209T111029+0000     verify_pack_version(pack_metadata=pack_metadata, use_python3=use_python3)
    st2vagrant: 20210209T111029+0000   File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/pack_management.py", line 464, in verify_pack_version
    st2vagrant: 20210209T111029+0000     raise ValueError(msg)
    st2vagrant: 20210209T111029+0000 ValueError: Pack "st2" requires Python 3.x, but current Python version is "2.7.12". You can override this restriction by providing the "force" flag, but the pack is not guaranteed to work.
    st2vagrant: 20210209T111029+0000 "
    st2vagrant: 20210209T111029+0000       stdout: ''
    st2vagrant: 20210209T111029+0000     task_id: download_pack
    st2vagrant: 20210209T111029+0000     type: error
    st2vagrant: 20210209T111029+0000   output:
    st2vagrant: 20210209T111029+0000     conflict_list: null
    st2vagrant: 20210209T111029+0000     message: ''
    st2vagrant: 20210209T111029+0000     packs_list: null
    st2vagrant: 20210209T111029+0000     warning_list: null
    st2vagrant: 20210209T111029+0000 +--------------------------+------------------------+---------------+----------------+--------------------------+
    st2vagrant: 20210209T111029+0000 | id                       | status                 | task          | action         | start_timestamp          |
    st2vagrant: 20210209T111029+0000 +--------------------------+------------------------+---------------+----------------+--------------------------+
    st2vagrant: 20210209T111029+0000 | 60226da272f0df3ef3a458a4 | succeeded (0s elapsed) | init_task     | core.noop      | Tue, 09 Feb 2021         |
    st2vagrant: 20210209T111029+0000 |                          |                        |               |                | 11:10:26 UTC             |
    st2vagrant: 20210209T111029+0000 | 60226da372f0df3ef3a458b4 | failed (2s elapsed)    | download_pack | packs.download | Tue, 09 Feb 2021         |
    st2vagrant: 20210209T111029+0000 |                          |                        |               |                | 11:10:27 UTC             |
    st2vagrant: 20210209T111029+0000 +--------------------------+------------------------+---------------+----------------+--------------------------+
    st2vagrant: 20210209T111029+0000 ############### ERROR ###############
    st2vagrant: 20210209T111029+0000 # Failed on Verify st2 #
    st2vagrant: 20210209T111029+0000 #####################################
```