### PR TITLE
Added tasks option to execution rerun

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.2
+
+* Added tasks option to `executions_re_run` to support re-running the execution from specific task.
+
 ## 2.0.1
 
 * Temporarily re-add Python 2 support until StackStorm v3.3 is EOL.

--- a/actions/executions_re_run.py
+++ b/actions/executions_re_run.py
@@ -13,9 +13,10 @@ def format_result(item):
 
 
 class St2ExecutionsReRunAction(St2BaseAction):
-    def run(self, id, parameters=None):
+    def run(self, id, parameters=None, tasks=None):
         parameters = parameters or {}
         result = self.client.liveactions.re_run(execution_id=id,
-                                                parameters=parameters)
+                                                parameters=parameters,
+                                                tasks=tasks)
         result = format_result(item=result)
         return result

--- a/actions/executions_re_run.yaml
+++ b/actions/executions_re_run.yaml
@@ -13,3 +13,7 @@ parameters:
     type: "object"
     description: "Parameter overrides"
     required: false
+  tasks:
+    type: "array"
+    description: "List of tasks to re-run"
+    required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: st2
 name: st2
 description: StackStorm utility actions and aliases
-version: 2.0.1
+version: 2.0.2
 python_versions:
   # StackStorm v3.3 on Xenial still uses python 2.7
   # and does not backtrack to find older supported versions,


### PR DESCRIPTION
#### Description
In order to be able to re-run the execution from specific task, this parameter needs to be exposed in execution re-run method.
 
Execution is capable to handle this parameter according to this : https://github.com/StackStorm/st2/blob/master/st2client/st2client/commands/action.py#L1790-L1793
 
#### Testing:
Tested locally, rerunning the workflow by id and supplying the task parameter.
Relevant output from the re_run:
```
   "context": {
     "re-run": {
       "ref": "682f7b112a47c69a4be47e02",
       "tasks": [
         "check_if_empty"
       ],
       "reset": [
         "check_if_empty"
       ]
     },
```